### PR TITLE
feat: nemo integration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,6 +74,8 @@ nfpms:
         dst: /usr/lib/systemd/user/rclone@.service
       - src: ./assets/google_drive_opener.py
         dst: /usr/share/nautilus-python/extensions/google_drive_opener.py
+      - src: ./assets/google_drive_opener.py
+        dst: /usr/share/nemo-python/extensions/google_drive_opener.py
       - src: ./assets/adfinis-rclone-mgr.desktop
         dst: /usr/share/applications/adfinis-rclone-mgr.desktop
       - src: ./assets/adfinis-rclone-mgr.png
@@ -130,6 +132,8 @@ aurs:
       install -Dm644 "./assets/rclone@.service" "${pkgdir}/usr/lib/systemd/user/rclone@.service"
       # nautilus extension
       install -Dm644 "./assets/google_drive_opener.py" "${pkgdir}/usr/share/nautilus-python/extensions/google_drive_opener.py"
+      # nemo extension
+      install -Dm644 "./assets/google_drive_opener.py" "${pkgdir}/usr/share/nemo-python/extensions/google_drive_opener.py"
       # desktop integration
       install -Dm644 "./assets/adfinis-rclone-mgr.desktop" "${pkgdir}/usr/share/applications/adfinis-rclone-mgr.desktop"
       install -Dm644 "./assets/adfinis-rclone-mgr.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/adfinis-rclone-mgr.png"

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ This repository provides a streamlined way to mount Google Drive using Rclone, t
 1. Install the dependencies
    ```bash
    # debian / ubuntu
-   sudo apt install rclone python3-nautilus zenity
+   sudo apt install rclone python3-nautilus python3-httpx zenity
 
    # fedora / rhel
-   sudo dnf install rclone nautilus-python zenity
+   sudo dnf install rclone nautilus-python python-httpx zenity
 
    # arch
-   sudo pacman -S rclone python-nautilus zenity
+   sudo pacman -S rclone python-nautilus python-httpx zenity
    ```
 2. Clone the repository:
    ```bash
@@ -74,6 +74,10 @@ This repository provides a streamlined way to mount Google Drive using Rclone, t
 2. Open the provided URL in your browser to configure Google Drive mounts.
 3. Follow the on-screen instructions to log in, select drives, and generate configurations.
 4. Use the Nautilus context menu to open files directly in Google Drive or to copy files and folders between Google Drives using the special "Copy on Google Drive" action.
+
+### Nemo support
+There is also a Nemo extension that gets installed. If Nemo is your file manager of choice,
+make sure you also have `nemo-python` installed for the integration to work.
 
 ### Managing Mounts
 

--- a/assets/google_drive_opener.py
+++ b/assets/google_drive_opener.py
@@ -1,17 +1,26 @@
-from gi.repository import Nautilus, GObject
+import sys
+from gi.repository import GObject
 import os
 import subprocess
 import httpx
 
+# hacky but most reliable way to detect if we're running within Nemo. We always fall
+# back to Nautilus
+if sys.argv[0] == "nemo":
+    from gi.repository import Nemo as FileManager
+else:
+    from gi.repository import Nautilus as FileManager
+
 """
-This extension adds a context menu item to Nautilus for opening files in Google Drive.
+This extension adds a context menu item to Nautilus and Nemo for opening files in Google
+Drive.
 It generates a public link using rclone and opens it in the default web browser.
 
 The extension expects rclone to mount the drives at ~/google/$drive_name.
 """
 
 
-class GoogleDriveOpener(GObject.GObject, Nautilus.MenuProvider):
+class GoogleDriveOpener(GObject.GObject, FileManager.MenuProvider):
     RCLONE_MOUNT_PATH = os.path.expanduser("~/google")
 
     def get_file_items(self, *args):
@@ -26,7 +35,7 @@ class GoogleDriveOpener(GObject.GObject, Nautilus.MenuProvider):
             file_paths.append(file_path)
 
         items = []
-        open_google_drive_item = Nautilus.MenuItem(
+        open_google_drive_item = FileManager.MenuItem(
             name="GoogleDriveOpener::OpenPublicURL",
             label="Open in Google Drive",
             tip="Open the file in Google Drive",
@@ -34,7 +43,7 @@ class GoogleDriveOpener(GObject.GObject, Nautilus.MenuProvider):
         open_google_drive_item.connect("activate", self.open_rclone_url, file_paths)
         items.append(open_google_drive_item)
 
-        copy_file_item = Nautilus.MenuItem(
+        copy_file_item = FileManager.MenuItem(
             name="GoogleDriveOpener::CopyFile",
             label="Copy on Google Drive",
             tip="Copy on Google Drive",
@@ -42,7 +51,7 @@ class GoogleDriveOpener(GObject.GObject, Nautilus.MenuProvider):
         copy_file_item.connect("activate", self.copy_file, file_paths)
         items.append(copy_file_item)
 
-        move_file_item = Nautilus.MenuItem(
+        move_file_item = FileManager.MenuItem(
             name="GoogleDriveOpener::MoveFile",
             label="Move on Google Drive",
             tip="Move on Google Drive",
@@ -50,7 +59,7 @@ class GoogleDriveOpener(GObject.GObject, Nautilus.MenuProvider):
         move_file_item.connect("activate", self.move_file, file_paths)
         items.append(move_file_item)
 
-        duplicate_file_item = Nautilus.MenuItem(
+        duplicate_file_item = FileManager.MenuItem(
             name="GoogleDriveOpener::DuplicateFile",
             label="Duplicate on Google Drive",
             tip="Duplicate on Google Drive",
@@ -60,7 +69,7 @@ class GoogleDriveOpener(GObject.GObject, Nautilus.MenuProvider):
 
         # add copy button if only one file is selected
         if len(file_paths) == 1:
-            copy_file_link_item = Nautilus.MenuItem(
+            copy_file_link_item = FileManager.MenuItem(
                 name="GoogleDriveOpener::CopyShareLink",
                 label="Copy File Link",
                 tip="Copy the file link to the clipboard",


### PR DESCRIPTION
This commits extends `google_drive_opener.py` in a way to make it usable
as Nautlus, but also as Nemo extension.
Additionally also `.goreleaser.yml` is extended, to install both
extensions. In order to not clutter our main target machines, that use
Gnome/Nautilus, the dependency for the Nemo extension (`nemo-python`) is
not automatically installed.

The README is updated to mention the Nemo integration.

Drive-by: While on it, also the manual install steps are extended with the
missing `python-httpx` dependency.

Closes #92